### PR TITLE
Add a service for tracing so pods can submit apm traces

### DIFF
--- a/stable/datadog/templates/trace-service.yaml
+++ b/stable/datadog/templates/trace-service.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.datadog.apmEnabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "datadog.fullname" . }}
+  labels:
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  type: {{ .Values.serviceType }}
+  selector:
+    app: {{ template "datadog.fullname" . }}
+  ports:
+  {{- if .Values.datadog.apmEnabled }}
+  - port: 8126
+    name: traceport
+    protocol: TCP
+    targetPort: 8126
+  {{- end }}
+{{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR will enable pods to report their traces back to the datadog agent pods via a service. This allows the use of KubeDNS namespacs to resolve the hostname given to the pods via environment variable.
